### PR TITLE
Add timeout flag & re-usable context

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ Simply, go-stare can be run with:
 
 This will display help for the tool. Here are all the switches it supports.
 
-| **Flag**          	| **Description**                                        	|
-|-------------------	|--------------------------------------------------------	|
-| -t, --target      	| Target to captures _(single target URL or list)_       	|
-| -c, --concurrency 	| Set the concurrency level _(default: 5)_              	|
-| -o, --output      	| Screenshot directory output results _(default: ./out)_ 	|
-| -q, --quality     	| Image quality to produce _(default: 75)_               	|
-| -v, --verbose     	| Verbose mode                                           	|
+| **Flag**          	| **Description**                                               |
+|-------------------	|-----------------------------------------------------------    |
+| -t, --target      	| Target to captures _(single target URL or list)_              |
+| -c, --concurrency 	| Set the concurrency level _(default: 5)_                      |
+| -o, --output      	| Screenshot directory output results _(default: ./out)_        |
+| -q, --quality     	| Image quality to produce _(default: 75)_                      |
+| -T, --timeout     	| Maximum time (seconds) allowed for connection _(default: 10)_ |
+| -v, --verbose     	| Verbose mode                                                  |
 
 ### Target
 

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ If you are still confused or found a bug, please [open the issue](https://github
 
 ## Version
 
-**Current version is 0.0.1** and still development.
+**Current version is 0.0.2** and still development.

--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func init() {
 	flag.Int64Var(&cfg.Quality, "quality", 75, "")
 	flag.Int64Var(&cfg.Quality, "q", 75, "")
 
+	flag.IntVar(&cfg.Timeout, "timeout", 10, "")
+	flag.IntVar(&cfg.Timeout, "T", 10, "")
+
 	flag.BoolVar(&cfg.Verbose, "verbose", false, "")
 	flag.BoolVar(&cfg.Verbose, "v", false, "")
 
@@ -63,6 +66,7 @@ func init() {
 		h += "  -c, --concurrency <int>     Set the concurrency level (default: 50)\n"
 		h += "  -o, --output <DIR>          Screenshot directory output results (default: ./out)\n"
 		h += "  -q, --quality <int>         Image quality to produce (default: 75)\n"
+		h += "  -T, --timeout <int>         Maximum time (seconds) allowed for connection (default: 10)\n"
 		h += "  -v, --verbose               Verbose mode\n\n"
 
 		h += "Examples:\n"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	author  = "dwisiswant0"
-	version = "0.0.1"
+	version = "0.0.2"
 	banner  = `
                       _
    __ _  ___ ____ ___| |_ __ _ _ __ ___ 


### PR DESCRIPTION
### Summary

<!-- Please provide enough information so that others can review your pull request. -->

Maximum time in seconds that you allow connection to take. This only limits the connection phase, which will still result in a screenshot even if the timeout is exceeded.

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Bug #1 
- Re-useable context

<!-- What existing problem does the pull request solve? -->

### Closing issues

Fixes #1 